### PR TITLE
Update nl.yml

### DIFF
--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -23,7 +23,7 @@ nl:
     September: September
     October: Oktober
     November: November
-    December: Dezember
+    December: December
     Mon: Ma
     Tue: Di
     Wed: Wo


### PR DESCRIPTION
Annoying typo in the month December (it was spelled with a z, which is German, but not Dutch).
